### PR TITLE
Update docs to emphasize use of viem

### DIFF
--- a/pages/sdk/installation.mdx
+++ b/pages/sdk/installation.mdx
@@ -3,24 +3,14 @@ import { Tab, Tabs } from "nextra-theme-docs";
 
 # Installation
 
-The Tokenbound SDK is compatible with Ethers and viem. Install the correct version of the SDK based on the library you are using in your application.
+The Tokenbound SDK is compatible with viem and Ethers. Install the correct version of the SDK based on the library you are using in your application.
+
+Note: If making use of one of the many starter kits, please make sure that you're using a recent release of viem (>1.0), Ethers 5.7+, or 6 to avoid issues.
 
 <Tabs items={["pnpm", "yarn", "npm"]}>
-  <Tab>
-  ```bash
-  pnpm install @tokenbound/sdk
-  ```
-  </Tab>
-  <Tab>
-  ```bash
-  yarn add @tokenbound/sdk
-  ```
-  </Tab>
-  <Tab>
-  ```bash
-  npm install @tokenbound/sdk
-  ```
-  </Tab>
+  <Tab>```bash pnpm install @tokenbound/sdk ```</Tab>
+  <Tab>```bash yarn add @tokenbound/sdk ```</Tab>
+  <Tab>```bash npm install @tokenbound/sdk ```</Tab>
 </Tabs>
 
 ---

--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -4,17 +4,19 @@
 
 The TokenboundClient is instantiated with an object containing at most two parameters:
 `chainId` (mandatory)
+`walletClient` (optional) OR
 `signer` (optional)
-Use either an Ethers `signer` OR viem `walletClient`, for transactions that require a user to sign.
+
+Use either a viem `walletClient` OR an Ethers `signer` for transactions that require a user to sign. Note that viem is an SDK dependency. Use of Ethers signer is recommended only for legacy projects.
 
 ```ts
-const tokenboundClient = new TokenboundClient({ signer, chainId: 1 });
+const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 });
 ```
 
 **OR**
 
 ```ts
-const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 });
+const tokenboundClient = new TokenboundClient({ signer, chainId: 1 });
 ```
 
 | Parameter |           |


### PR DESCRIPTION
Sleight re-emphasis of viem in ordering and wording.

Also addresses issues raised at ETHGlobal re: Web3 starter kits having older dependencies