### PR TITLE
document custom implementation params for TokenboundClient

### DIFF
--- a/pages/sdk/customAccounts.mdx
+++ b/pages/sdk/customAccounts.mdx
@@ -7,16 +7,18 @@ Custom 6551 account implementations are now supported in the SDK.
 If you've deployed your own implementation, you can optionally pass the custom configuration when instantiating your TokenboundClient:
 
 ```javascript
-const CUSTOM_6551_IMPLEMENTATION = {
+import { TokenboundClient, Custom6551Implementation } from "@tokenbound/sdk";
+
+const CUSTOM_6551_IMPLEMENTATION: Custom6551Implementation = {
   implementationAddress: "<custom_implementation_address>",
   registryAddress: "<custom_registry_address>",
 };
 
-const result = tokenboundClient.getAccount({
-  tokenContract: "<token_contract_address>",
-  tokenId: "<token_id>",
-  customImplementation: CUSTOM_6551_IMPLEMENTATION,
-});
+const tokenboundClient = new TokenboundClient({
+    signer: <signer>,
+    chainId: <chainId>,
+    customImplementation: CUSTOM_6551_IMPLEMENTATION
+})
 ```
 
 If, for any reason, you need to override the custom implementation, you can:

--- a/pages/sdk/customAccounts.mdx
+++ b/pages/sdk/customAccounts.mdx
@@ -2,7 +2,37 @@ import { Callout } from "nextra-theme-docs";
 
 # Custom Accounts
 
-Support for custom ERC-6551 account implementations is coming soon.
+Custom 6551 account implementations are now supported in the SDK.
+
+If you've deployed your own implementation, you can optionally pass the custom configuration when instantiating your TokenboundClient:
+
+```javascript
+const CUSTOM_6551_IMPLEMENTATION = {
+  implementationAddress: "<custom_implementation_address>",
+  registryAddress: "<custom_registry_address>",
+};
+
+const result = tokenboundClient.getAccount({
+  tokenContract: "<token_contract_address>",
+  tokenId: "<token_id>",
+  customImplementation: CUSTOM_6551_IMPLEMENTATION,
+});
+```
+
+If, for any reason, you need to override the custom implementation, you can:
+
+1. Create another instance of TokenboundClient OR
+2. Override `implementationAddress` and `registryAddress` directly on when calling `getAccount`,
+   `prepareCreateAccount`, `createAccount`, or `computeAccount`:
+
+```javascript
+const result = tokenboundClient.getAccount({
+  tokenContract: "<token_contract_address>",
+  tokenId: "<token_id>",
+  implementationAddress: "<custom_implementation_address>",
+  registryAddress: "<custom_registry_address>",
+});
+```
 
 ---
 


### PR DESCRIPTION
Supporting documentation for SDK features surrounding custom 6551 account/registry implementations: https://github.com/tokenbound/sdk/pull/11