### PR TITLE
Add example apps to docs site

### DIFF
--- a/pages/sdk/installation.mdx
+++ b/pages/sdk/installation.mdx
@@ -13,6 +13,14 @@ Note: If making use of one of the many Web3 starter kits, please make sure that 
   <Tab>```bash npm install @tokenbound/sdk ```</Tab>
 </Tabs>
 
+## Example apps
+
+To help you get started more quickly, we've assembled bare-bones [example apps using the Tokenbound SDK](https://github.com/tokenbound/sdk/tree/main/examples) using viem, Ethers 5.7, and Ethers 6 respectively
+
+[vite-wagmi-viem](https://github.com/tokenbound/sdk/tree/main/examples/vite-wagmi-viem)
+[vite-wagmi-ethers](https://github.com/tokenbound/sdk/tree/main/examples/vite-wagmi-ethers)
+[vite-wagmi-ethers6](https://github.com/tokenbound/sdk/tree/main/examples/vite-wagmi-ethers6)
+
 ---
 
 <Callout emoji="✍🏽">

--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -8,6 +8,7 @@ The TokenboundClient is instantiated with an object containing at most two param
 `signer` (optional)
 
 Use either a viem `walletClient` OR an Ethers `signer` for transactions that require a user to sign. Note that viem is an SDK dependency. Use of Ethers signer is recommended only for legacy projects.
+For easy reference, have a look at [example apps using each method](https://github.com/tokenbound/sdk/tree/main/examples)
 
 ```ts copy
 const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 });


### PR DESCRIPTION
Previously, we had installation instructions and method usage but were not linking users to example implementations where we show how walletClient/signer are instantiated + wired to the TokenboundClient. This fixes that.