### PR TITLE
clarify installation: viem vs. ethers

### DIFF
--- a/pages/sdk/customAccounts.mdx
+++ b/pages/sdk/customAccounts.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra-theme-docs";
 
 # Custom Accounts
 
-Custom 6551 account implementations are now supported in the SDK.
+Custom ERC-6551 account implementations are now supported in the SDK.
 
 If you've deployed your own implementation, you can optionally pass custom configuration parameters when instantiating your TokenboundClient:
 

--- a/pages/sdk/installation.mdx
+++ b/pages/sdk/installation.mdx
@@ -7,10 +7,12 @@ The Tokenbound SDK is compatible with viem and Ethers. Install the correct versi
 
 Note: If making use of one of the many Web3 starter kits, please make sure that you're using a recent release of viem (>1.0), Ethers 5.7+, or 6 to avoid issues.
 
+viem is a core SDK dependency, so we recommend using viem except for legacy Ethers projects.
+
 <Tabs items={["pnpm", "yarn", "npm"]}>
-  <Tab>```bash pnpm install @tokenbound/sdk ```</Tab>
-  <Tab>```bash yarn add @tokenbound/sdk ```</Tab>
-  <Tab>```bash npm install @tokenbound/sdk ```</Tab>
+  <Tab>```pnpm install @tokenbound/sdk ```</Tab>
+  <Tab>```yarn add @tokenbound/sdk ```</Tab>
+  <Tab>```npm install @tokenbound/sdk ```</Tab>
 </Tabs>
 
 ## Example apps

--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -7,7 +7,7 @@ The TokenboundClient is instantiated with an object containing at most two param
 `walletClient` (optional) OR
 `signer` (optional)
 
-Use either a viem `walletClient` OR an Ethers `signer` for transactions that require a user to sign. Note that viem is an SDK dependency. Use of Ethers signer is recommended only for legacy projects.
+Use either a viem `walletClient` OR an Ethers `signer` for transactions that require a user to sign. Note that viem is an SDK dependency, so walletClient is preferable for most use cases. Use of Ethers signer is recommended only for legacy projects.
 For easy reference, we've prepared [SDK code examples](https://github.com/tokenbound/sdk/tree/main/examples) for each method.
 
 ```ts copy
@@ -20,10 +20,11 @@ const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 });
 const tokenboundClient = new TokenboundClient({ signer, chainId: 1 });
 ```
 
-| Parameter |           |
-| --------- | --------- |
-| signer    | optional  |
-| chainId   | mandatory |
+| Parameter    |           |
+| ------------ | --------- |
+| walletClient | optional  |
+| signer       | optional  |
+| chainId      | mandatory |
 
 Then use the TokenboundClient to interact with the Tokenbound contracts and Tokenbound accounts:
 


### PR DESCRIPTION
viem is an internal dependency, so we generally advise use of viem over ethers. Here we do a better job of highlighting this in various parts of the docs.