### PR TITLE
Add in Optimism Account Implementation Address to Docs

### DIFF
--- a/pages/contracts/deployments.mdx
+++ b/pages/contracts/deployments.mdx
@@ -30,6 +30,7 @@ The Tokenbound account implementation has also been deployed to both goerli and 
 | Mumbai      | [0x2d25602551487c3f3354dd80d76d54383a243358](https://mumbai.polygonscan.com/address/0x2d25602551487c3f3354dd80d76d54383a243358) |
 | Mainnet     | [0x2d25602551487c3f3354dd80d76d54383a243358](https://etherscan.io/address/0x2d25602551487c3f3354dd80d76d54383a243358)           |
 | Polygon     | [0x2d25602551487c3f3354dd80d76d54383a243358](https://polygonscan.com/address/0x2d25602551487c3f3354dd80d76d54383a243358)        |
+| Optimism    | [0x2d25602551487c3f3354dd80d76d54383a243358](https://optimistic.com/address/0x2d25602551487c3f3354dd80d76d54383a243358)         |
 
 ---
 


### PR DESCRIPTION
As part of adding in support for Optimism I deployed the [Account Implementation](https://optimistic.etherscan.io/address/0x2d25602551487c3f3354dd80d76d54383a243358) and the [Account](https://optimistic.etherscan.io/address/0x1a0E97Dae78590b7E967E725a5c848eD034f5510).

I am simply adding in the extra line to the docs to show that it is now supported!