### PR TITLE
change return type of createAccount to match latest PR

### DIFF
--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -83,7 +83,7 @@ console.log(preparedAccount) //0x1a2...3b4cd
 
 ### createAccount
 
-**Returns** the transaction hash of the transaction that created the tokenbound account for a given token contract and token ID.
+**Returns** the account address of the tokenbound account created. If an account already exists, the existing account is returned.
 
 ```typescript
 const account = await tokenboundClient.createAccount({


### PR DESCRIPTION
Previously, createAccount was returning the txHash from creation of the account in the SDK.

Per EIP spec, createAccount should return the created account address.

This PR changes the return type to match the spec.