### PR TITLE
Enable chain as alternate to chainId in params

### DIFF
--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -3,28 +3,33 @@
 ### TokenboundClient
 
 The TokenboundClient is instantiated with an object containing two parameters:
-`chainId` (mandatory)
-`walletClient` (optional) OR
-`signer` (optional)
 
-Use either a viem `walletClient` [(see walletClient docs)](https://viem.sh/docs/clients/wallet.html) OR an Ethers `signer` [(see signer docs)](https://docs.ethers.org/v5/api/signer/) for transactions that require a user to sign. Note that viem is an SDK dependency, so walletClient is preferable for most use cases. _Use of Ethers signer is recommended only for legacy projects_.
+| Parameter                             |           |
+| ------------------------------------- | --------- |
+| One of **signer** _or_ **walletClient** | mandatory |
+| One of **chainId** _or_ **chain**       | mandatory |
+
+`chainId` sets `Chain` using internal imports from [`viem/chains`](https://viem.sh/docs/clients/chains.html) for each of the [ERC-6551 contract deployments](https://docs.tokenbound.org/contracts/deployments). If using an unlisted deployment, you'll need to pass the full `Chain` as parameter.
+
+Use either a viem `walletClient` [(see walletClient docs)](https://viem.sh/docs/clients/wallet.html) *or* an Ethers `signer` [(see signer docs)](https://docs.ethers.org/v5/api/signer/) for transactions that require a user to sign. Note that viem is an SDK dependency, so walletClient is preferable for most use cases. _Use of Ethers signer is recommended only for legacy projects_.
 For easy reference, we've prepared [SDK code examples](https://github.com/tokenbound/sdk/tree/main/examples) for a few simple SDK interactions.
 
+
+**Standard configuration**
 ```ts copy
 const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 })
 ```
 
-**OR**
+**Custom chain**
+```ts copy
+import { zora } from 'viem/chains'
+const tokenboundClient = new TokenboundClient({ walletClient, chain: zora })
+```
 
+**Using Ethers.js**
 ```ts copy
 const tokenboundClient = new TokenboundClient({ signer, chainId: 1 })
 ```
-
-| Parameter        |           |
-| ---------------- | --------- |
-| **walletClient** | optional  |
-| **signer**       | optional  |
-| **chainId**      | mandatory |
 
 Then use the TokenboundClient to interact with the Tokenbound contracts and Tokenbound accounts:
 

--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -345,6 +345,8 @@ console.log(segmentedBytecode)
 
 Gets an [EIP-191](https://eips.ethereum.org/EIPS/eip-191) formatted signature for a message.
 
+**Returns** a Promise that resolves to a signed Hex string
+
 The message to be signed is typed as `UniversalSignableMessage` so that it can elegantly handle Ethers 5, Ethers 6, and viem's expected types for all signable formats. Check the types associated with signMessage for [viem](https://viem.sh/docs/actions/wallet/signMessage.html), [Ethers 5](https://docs.ethers.org/v5/api/signer/#Signer-signMessage), and [Ethers 6](https://docs.ethers.org/v6/api/providers/#Signer-signMessage) as needed.
 
 ```ts
@@ -356,8 +358,6 @@ const uint8ArrayMessage: Uint8Array = new Uint8Array([72, 101, 108, 108, 111]) /
 ```
 
 Note that this method is just for convenience. Since your EOA wallet is responsible for signing, messages can also be signed explicitly using your EOA wallet address in viem or Ethers.
-
-**Returns** a Promise that resolves to a signed Hex string
 
 ```ts
 const signedMessage = await tokenboundClient.signMessage({


### PR DESCRIPTION
Re: https://github.com/tokenbound/sdk/pull/37

In order to reduce the package size, we eliminated all but the documented deployed chains from the bundle. Custom / unlisted chains can be used, but need to be passed as a full viem `Chain` object when instantiating the TokenboundClient.

This is documented here.