### PR TITLE
Clarify transfer docs

### DIFF
--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -2,16 +2,19 @@
 
 ### TokenboundClient
 
+The TokenboundClient class provides an interface for interacting with tokenbound accounts, enabling operations like account creation, transaction execution, token transfers (including ERC-721, ERC-1155, and ERC-20 tokens), and message signing.
+
 The TokenboundClient is instantiated with an object containing two parameters:
 
-| Parameter                             |           |
-| ------------------------------------- | --------- |
+| Parameter                               |           |
+| --------------------------------------- | --------- |
 | One of **signer** _or_ **walletClient** | mandatory |
 | One of **chainId** _or_ **chain**       | mandatory |
 
 `chainId` sets `Chain` using internal imports from [`viem/chains`](https://viem.sh/docs/clients/chains.html) for each of the [ERC-6551 contract deployments](https://docs.tokenbound.org/contracts/deployments). If using an unlisted deployment, you'll need to pass the full `Chain` as parameter.
 
 Use either a viem `walletClient` [(see walletClient docs)](https://viem.sh/docs/clients/wallet.html) *or* an Ethers `signer` [(see signer docs)](https://docs.ethers.org/v5/api/signer/) for transactions that require a user to sign. Note that viem is an SDK dependency, so walletClient is preferable for most use cases. _Use of Ethers signer is recommended only for legacy projects_.
+
 For easy reference, we've prepared [SDK code examples](https://github.com/tokenbound/sdk/tree/main/examples) for a few simple SDK interactions.
 
 
@@ -160,7 +163,7 @@ console.log({ tokenContract, tokenId, chainId })
 ```typescript
 const preparedCall = await tokenboundClient.prepareExecuteCall({
   account: "<account_address>",
-  to: "<recipient_address>",
+  to: "<contract_address>",
   value: "<wei_value>",
   data: "<data>",
 })
@@ -171,7 +174,7 @@ console.log(preparedCall) //...
 | Parameter   | Description                     | Type   |
 | ----------- | ------------------------------- | ------ |
 | **account** | The Tokenbound account address. | string |
-| **to**      | The recipient address.          | string |
+| **to**      | The contract address.           | string |
 | **value**   | The value to send, in wei.      | bigint |
 | **data**    | The data to send.               | string |
 
@@ -186,7 +189,7 @@ Performs an arbitrary contract call against any contract. This means any onchain
 ```typescript
 const executedCall = await tokenboundClient.executeCall({
   account: "<account_address>",
-  to: "<recipient_address>",
+  to: "<contract_address>",
   value: "<wei_value>",
   data: "<encoded_call_data>",
 })
@@ -197,9 +200,9 @@ console.log(executedCall)
 | Parameter           | Description                     | Type          |
 | ------------------- | ------------------------------- | ------------- |
 | **account**         | The Tokenbound account address. | string        |
-| **to**              | The recipient address.          | string        |
+| **to**              | The contract address.           | string        |
 | **value**           | The value to send, in wei.      | bigint        |
-| **data** (optional) | The ABI-encoded call data       | `0x{string}`  |
+| **data** (optional) | The ABI-encoded call data.      | `0x{string}`  |
 
 Here's a more robust example, where we see how to use your TBA to mint an NFT using Zora's [ERC721Drop contract](https://etherscan.io/address/0x7c74dfe39976dc395529c14e54a597809980e01c#code) by calling the contract's `purchase` function.
 
@@ -251,13 +254,13 @@ const transferNFT = await tokenboundClient.transferNFT({
 console.log(transferNFT) //...
 ```
 
-| Parameter            | Description                       | Type   |
-| -------------------- | --------------------------------- | ------ |
-| **account**          | The Tokenbound account address.   | string |
-| **tokenType**        | Token type: 'ERC721' or 'ERC1155' | string |
-| **tokenContract**    | The recipient address.            | string |
-| **tokenId**          | The tokenId of the NFT.           | string |
-| **recipientAddress** | The recipient address.            | string |
+| Parameter            | Description                              | Type   |
+| -------------------- | ---------------------------------------- | ------ |
+| **account**          | The Tokenbound account address.          | string |
+| **tokenType**        | Token type: 'ERC721' or 'ERC1155'        | string |
+| **tokenContract**    | The address of the token contract.       | string |
+| **tokenId**          | The tokenId of the NFT.                  | string |
+| **recipientAddress** | The recipient address or ENS.            | string |
 
 ---
 
@@ -281,7 +284,7 @@ console.log(transferERC20) //...
 | -------------------- | --------------------------------------- | ------ |
 | **account**          | The Tokenbound account address.         | string |
 | **amount**           | Amount, in decimal form (eg. 0.01 ETH). | number |
-| **recipientAddress** | The recipient address.                  | string |
+| **recipientAddress** | The recipient address or ENS.           | string |
 
 ---
 
@@ -307,7 +310,7 @@ console.log(transferERC20) //...
 | ---------------------- | ---------------------------------------------- | ------ |
 | **account**            | The Tokenbound account address.                | string |
 | **amount**             | Amount, in decimal form (eg. 0.1 USDC).        | number |
-| **recipientAddress**   | The recipient address.                         | string |
+| **recipientAddress**   | The recipient address or ENS.                  | string |
 | **erc20tokenAddress**  | The ERC-20 token address.                      | string |
 | **erc20tokenDecimals** | The ERC-20 token decimal specification (1-18). | number |
 
@@ -390,7 +393,7 @@ console.log(signedUint8Message)
 ## Advanced Usage
 ### Custom Account Implementation
 
-It is possible to implement your own custom implementation of an [account](/contracts/account) and make the SDK point to your custom implementation instead of the default implementation.
+If your team has deployed a custom [account implementation](/contracts/account) contract, you'll need to point the SDK to your custom implementation instead of the default implementation.
 
 ```javascript
 import { TokenboundClient } from "@tokenbound/sdk"
@@ -419,8 +422,6 @@ Read more [here](/guides/custom-accounts)
 If using viem, you can specify a custom PublicClient RPC URL for use by the TokenboundClient's internal PublicClient.
 
 Alternately, you can simply configure and pass your own publicClient. This option was added to enable internal testing on local chains.
-
-These options won't be useful to most users.
 
 | Parameter              |          |
 | ---------------------- | -------- |


### PR DESCRIPTION
- Use of ENS as recipient address
- Clarify executeCall params (recipient -> contract address)