### PR TITLE
clarify chain/chainId docs

### DIFF
--- a/pages/sdk/methods.mdx
+++ b/pages/sdk/methods.mdx
@@ -1,40 +1,44 @@
 # API Reference
 
-### TokenboundClient
+## TokenboundClient
 
 The TokenboundClient class provides an interface for interacting with tokenbound accounts, enabling operations like account creation, transaction execution, token transfers (including ERC-721, ERC-1155, and ERC-20 tokens), and message signing.
 
-The TokenboundClient is instantiated with an object containing two parameters:
+The client is instantiated with an object containing two parameters:
 
 | Parameter                               |           |
 | --------------------------------------- | --------- |
 | One of **signer** _or_ **walletClient** | mandatory |
 | One of **chainId** _or_ **chain**       | mandatory |
 
-`chainId` sets `Chain` using internal imports from [`viem/chains`](https://viem.sh/docs/clients/chains.html) for each of the [ERC-6551 contract deployments](https://docs.tokenbound.org/contracts/deployments). If using an unlisted deployment, you'll need to pass the full `Chain` as parameter.
 
 Use either a viem `walletClient` [(see walletClient docs)](https://viem.sh/docs/clients/wallet.html) *or* an Ethers `signer` [(see signer docs)](https://docs.ethers.org/v5/api/signer/) for transactions that require a user to sign. Note that viem is an SDK dependency, so walletClient is preferable for most use cases. _Use of Ethers signer is recommended only for legacy projects_.
 
-For easy reference, we've prepared [SDK code examples](https://github.com/tokenbound/sdk/tree/main/examples) for a few simple SDK interactions.
+### Standard configuration
 
+If you're using one of the **standard ERC-6551 contract deployments** (see: [V2 →](https://docs.tokenbound.org/contracts/deployments-v2), [V3 →](https://docs.tokenbound.org/contracts/deployments-v3)), you can simply pass the`chainId`. This will set `Chain` internally using imports from [`viem/chains`](https://viem.sh/docs/clients/chains.html). To keep the bundle size to a minimum, only standard chains are included in the SDK package.
 
-**Standard configuration**
 ```ts copy
 const tokenboundClient = new TokenboundClient({ walletClient, chainId: 1 })
 ```
 
-**Custom chain**
+### Custom chain
+
+If your chain isn't listed on the deployments page, you'll need to pass the full `Chain` object from the [`viem/chains`](https://viem.sh/docs/clients/chains.html) package using the `chain` parameter.
+
 ```ts copy
 import { zora } from 'viem/chains'
 const tokenboundClient = new TokenboundClient({ walletClient, chain: zora })
 ```
 
-**Using Ethers.js**
+### Using Ethers.js
 ```ts copy
+const { data: signer } = useSigner()
 const tokenboundClient = new TokenboundClient({ signer, chainId: 1 })
 ```
 
-Then use the TokenboundClient to interact with the Tokenbound contracts and Tokenbound accounts:
+### Making your first call
+Now you can use the TokenboundClient to interact with the Tokenbound contracts:
 
 ```ts copy
 const tokenboundClient = new TokenboundClient({ signer, chainId: 1 })
@@ -47,8 +51,11 @@ const tokenBoundAccount = tokenboundClient.getAccount({
 console.log(tokenBoundAccount) //0x1a2...3b4cd
 ```
 
----
+For easy reference, we've prepared [code examples](https://github.com/tokenbound/sdk/tree/main/examples) for a few simple SDK interactions.
 
+## TokenboundClient SDK Methods
+
+The TokenboundClient enables creation of and interaction with Tokenbound accounts:
 ### getAccount
 
 **Returns** the tokenbound account address for a given token contract and token ID.


### PR DESCRIPTION
Recent changes to the SDK removed the bulky chain imports from `viem/chains`, aside from those listed on the standard deployments pages. This reduced the bundle size by about 42%.

This PR clarifies this, and shows how devs can use chains from `viem/chains` that aren't bundled with the SDK page.