### PR TITLE
add Kiosk to showcase

### DIFF
--- a/pages/showcase/index.mdx
+++ b/pages/showcase/index.mdx
@@ -59,6 +59,13 @@ import { Card, Cards, Callout } from 'nextra/components'
       </div>
   </ShowcaseCard>
 
+  <ShowcaseCard title="Kiosk" href="https://tbkiosk.xyz/projects">
+    <>![Kiosk](https://i.imgur.com/AY4Cu6Q.png)</>
+    <div className="description">
+      Building the App Store For Smart NFTs.
+    </div>
+  </ShowcaseCard>
+
 </Cards>
 </div>
 


### PR DESCRIPTION
Requesting the addition of Kiosk `tbkiosk.xyz` to Tokenbound showcase